### PR TITLE
Angclust n419

### DIFF
--- a/bin/desi_hiz_angclust
+++ b/bin/desi_hiz_angclust
@@ -10,12 +10,14 @@ from desihiz.hizmerge_io import (
     allowed_imgs,
     get_img_dir,
     get_img_bands,
+    get_ext_coeffs,
 )
 from desihiz.angclust_io import (
     allowed_fields,
     get_angclust_targs,
     add_vi,
 )
+from desihiz.laelf_utils import get_filt_lminmax, get_filtflam
 from argparse import ArgumentParser
 
 log = get_logger()
@@ -89,7 +91,28 @@ def main():
         log.info("{}\t{}".format(kwargs[0], kwargs[1]))
 
     d = get_angclust_targs(args.img, args.band)
+
+    # AR overwrite LINEFLUX, use ext.-corr. mag.
+    # AR (see emails with Arjun from 2024/04/12)
+    if "LINEFLUX" in d.colnames:
+        d.remove_column("LINEFLUX")
+    if "lineflux" in d.colnames:
+        d.remove_column("lineflux")
+    ext_coeff = get_ext_coeffs(args.img)[args.img.upper()][args.band]
+    mags = 22.5 - 2.5 * np.log10(d["FLUX_{}".format(args.band)]) - ext_coeff * d["EBV"]
+    filt = get_filt_lminmax(args.img)[args.band]
+    lmin, lmax = filt["lmin"], filt["lmax"]
+    filt_cen, filt_wid = 0.5 * (lmin + lmax), lmax - lmin
+    log.info(
+        "add LINEFLUX using: (filt_cen, filt_wid) = ({}, {})".format(
+            filt_cen, filt_wid,
+        )
+    )
+    d["LINEFLUX"] = get_filtflam(mags, filt_cen, filt_wid)
+
+    # AR add vi
     add_vi(d, args.img, args.band, args.mergefn)
+
     d.write(args.outfn, overwrite=args.overwrite)
 
 

--- a/bin/desi_hiz_angfoot_odin_n419_cosmos_yr2
+++ b/bin/desi_hiz_angfoot_odin_n419_cosmos_yr2
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+
+"""
+defines a hp map with reporting if a pixel contains a photometric object.
+for odin/n419/cosmos_yr2 only.
+"""
+
+import os
+import fitsio
+import numpy as np
+from astropy.table import Table
+import healpy as hp
+from desihiz.hizmerge_io import (
+    allowed_imgs,
+    get_img_cases,
+    get_img_bands,
+    get_phot_fns,
+)
+from argparse import ArgumentParser
+
+
+def parse():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--outfn",
+        help="output fits filename (default=None)",
+        type=str,
+        required=True,
+        default=None,
+    )
+    parser.add_argument(
+        "--bb",
+        help="broad-band imaging; for odin-only (default=HSC)",
+        type=str,
+        choices=["HSC", "LS"],
+        default="HSC",
+    )
+    parser.add_argument(
+        "--nside",
+        help="hp nside (default=8192)",
+        type=int,
+        default=8192,
+    )
+    parser.add_argument(
+        "--overwrite",
+        help="overwrite files",
+        action="store_true",
+    )
+    args = parser.parse_args()
+    for kwargs in args._get_kwargs():
+        print(kwargs)
+    return args
+
+
+def main():
+
+    args = parse()
+
+    img, band, case = "odin", "N419", "cosmos_yr2"
+    nest = True
+
+    # AR photometry catalog
+    photfns = get_phot_fns(img, case, band)
+    if args.bb == "HSC":
+        photfn = [_ for _ in photfns if "_HSC_" in _][0]
+    if args.bb == "LS":
+        photfn = [_ for _ in photfns if "_DR10_" in _][0]
+    d = Table(fitsio.read(photfn))
+
+    # AR cut on brick_primary and maskbits
+    sel = d["brick_primary"]
+    sel &= d["maskbits"] == 0
+    d = d[sel]
+
+    # AR cut on nobs
+    if args.bb == "HSC":
+        bands = ["g", "r", "i", "z"]
+    if args.bb == "LS":
+        bands = ["g", "r", "z"]
+    sel = np.ones(len(d), dtype=bool)
+    for band in bands:
+        key = "forced_nexp_{}".format(band)
+        if (args.bb == "HSC") & (band in ["r", "i"]):
+            key2 = "forced_nexp_{}2".format(band)
+            sel &= ((d[key] > 0) & (d[key] < 999999)) | (
+                (d[key2] > 0) & (d[key2] < 999999)
+            )
+        else:
+            sel &= (d[key] > 0) & (d[key] < 999999)
+    d = d[sel]
+
+    # AR healpix pixels
+    pixs = hp.ang2pix(
+        args.nside, np.radians(90.0 - d["dec"]), np.radians(d["ra"]), nest=nest
+    )
+    unq_pixs = np.unique(pixs)
+
+    # AR initialize hp Table
+    hpd = Table()
+    hpd.meta["HPXNSID"], hpd.meta["HPXNEST"] = args.nside, nest
+    npix = hp.nside2npix(args.nside)
+    hpd["HPXPIXEL"] = np.arange(npix, dtype=int)
+    thetas, phis = hp.pix2ang(args.nside, hpd["HPXPIXEL"], nest=nest)
+    hpd["RA"], hpd["DEC"] = np.degrees(phis), 90.0 - np.degrees(thetas)
+    # AR restrict to relevant pixels
+    hpd.meta["PHOTFN"] = photfn
+    if args.bb == "HSC":
+        hpd.meta[
+            "SEL"
+        ] = "(brick_primary) & (maskbits==0) & (nobs_g>0) and (nobs_r>0 or nobs_r2>0) and (nobs_i>0 or nobs_i2>0) and (nobs_z>0)"
+    if args.bb == "LS":
+        hpd.meta[
+            "SEL"
+        ] = "(brick_primary) & (maskbits==0) & (nobs_g>0) and (nobs_r>0) and (nobs_z>0)"
+    sel = np.in1d(hpd["HPXPIXEL"], unq_pixs)
+    hpd = hpd[sel]
+    hpd.write(args.outfn, overwrite=args.overwrite)
+
+
+if __name__ == "__main__":
+    main()

--- a/py/desihiz/angclust_io.py
+++ b/py/desihiz/angclust_io.py
@@ -5,13 +5,15 @@ import os
 import fitsio
 import numpy as np
 from astropy.io import fits
-from astropy.table import Table
+from astropy.table import Table, vstack
+from desitarget.geomask import match
 from desiutil.log import get_logger
 from desihiz.hizmerge_io import (
     allowed_imgs,
     get_img_bands,
     get_phot_fns,
     get_ext_coeffs,
+    match_coord,
 )
 
 log = get_logger()
@@ -37,10 +39,131 @@ def get_angclust_targs(img, band):
                 fn = "/pscratch/sd/m/mwhite/AnalyzeLAE/odin/odin_lae_cosmos_N501.fits"
                 d = Table.read(fn)
                 d = d[d["Selection3"] == 1]
+        ODIN/N419 (COSMOS):
+            - reproducing AD "Selection3" sample
+            - there are two bb img sources, HSC and LS: for simplicity, for targets selected
+                by both imaging, we only report the HSC photometry.
+
     """
 
     assert img in allowed_imgs
     assert band in get_img_bands(img)
+
+    # odin/n419/cosmos
+    if (img == "odin") & (band == "N419"):
+
+        # for odin/n419, we only use cosmos_yr2 so far (not xmmlss_yr2)
+        # we have two tractor catalogs: HSC and LSDR10
+        # note that the {brickname,objid} are the same, as the HSC/LSDR10
+        #   difference is for the forced photometry
+
+        # first read the targets
+        fadir = os.path.join(
+            os.getenv("DESI_ROOT"), "survey", "fiberassign", "special", "tertiary", "0026"
+        )
+        fn = os.path.join(fadir, "inputcats", "COSMOS_LAE_Candidates_2023apr04v2.fits.gz")
+        t = Table(fitsio.read(fn))
+        sel = np.array(["LAE N419" in _ for _ in t["SELECTION"]])
+        t = t[sel]
+
+        # now loop on the HSC/LSDR10 catalogs
+        fns = get_phot_fns(img, "cosmos_yr2", band)
+        ds = {}
+
+        for fn in fns:
+
+            # HSC or LS ?
+            if os.path.basename(fn) == "ODIN_N419_tractor_HSC_forced_all.fits.gz":
+                bb_img = "HSC"
+            elif os.path.basename(fn) == "ODIN_N419_tractor_DR10_forced_all.fits.gz":
+                bb_img = "LS"
+            else:
+                msg = "unrecognized fn = {}".format(fn)
+                log.error(msg)
+                raise ValueError(msg)
+
+            # cut t on bb_img
+            sel = np.array(["LAE N419 ODIN+{}".format(bb_img) in _ for _ in t["SELECTION"]])
+            tcut = t[sel]
+            log.info("select {} targets for {}".format(sel.sum(), bb_img))
+
+            # read the tractor file
+            d = Table(fitsio.read(fn))
+            for key in d.colnames:
+                d[key].name = key.upper()
+            d["UNQID"] = ["{}-{}".format(b, o) for b, o in zip(d["BRICKNAME"], d["OBJID"])]
+            log.info("read {} rows from {}".format(len(d), fn))
+
+            # cross-match with the targets
+            # we want an exact match for all targets..
+            iid, iit, _, _, d2d = match_coord(d["RA"], d["DEC"], tcut["RA"], tcut["DEC"], search_radius=1.0)
+            assert iid.size == len(tcut)
+            assert np.all(d2d == 0.)
+            ds[bb_img] = d[iid]
+
+        # AR sanity check
+        assert np.unique(ds["HSC"]["UNQID"]).size == len(ds["HSC"])
+        assert np.unique(ds["LS"]["UNQID"]).size == len(ds["LS"])
+        iih, iil = match(ds["HSC"]["UNQID"], ds["LS"]["UNQID"])
+        assert np.abs(ds["HSC"]["RA"][iih] - ds["LS"]["RA"][iil]).max() == 0
+        assert np.abs(ds["HSC"]["DEC"][iih] - ds["LS"]["DEC"][iil]).max() == 0
+
+        # AR add dummy columns for r2, i2 for LS
+        assert len([key for key in ds["LS"].colnames if key not in ds["HSC"].colnames]) == 0
+        keys = [key for key in ds["HSC"].colnames if key not in ds["LS"].colnames]
+        log.info("add following keys to ds['LS']: {}".format(",".join(keys)))
+        for key in keys:
+            shape = list(ds["HSC"][key].shape)
+            shape[0] = len(ds["LS"])
+            shape = tuple(shape)
+            ds["LS"][key] = np.zeros_like(ds["HSC"][key], shape=shape)
+
+        # AR same key ordering, for vstack
+        ds["LS"] = ds["LS"][ds["HSC"].colnames]
+
+        # AR stack, start with HSC
+        # AR consequence: targets selected both by HSC and LS will
+        # AR    have the HSC photometry reported
+        d = ds["HSC"].copy()
+        d["HSC"], d["LS"] = True, False
+        sel = np.in1d(d["UNQID"], ds["LS"]["UNQID"])
+        d["LS"][sel] = True
+        sel = ~np.in1d(ds["LS"]["UNQID"], d["UNQID"])
+        d2 = ds["LS"][sel]
+        d2["HSC"], d2["LS"] = False, True
+        d = vstack([d, d2])
+
+        # mags
+        ext_coeffs = get_ext_coeffs(img)
+        n419_mags = (
+            22.5
+            - 2.5 * np.log10(d["FLUX_N419"])
+            - ext_coeffs["ODIN"]["N419"] * d["EBV"]
+        )
+        n501_mags = (
+            22.5
+            - 2.5 * np.log10(d["FLUX_N501"])
+            - ext_coeffs["ODIN"]["N501"] * d["EBV"]
+        )
+
+        # cut on AD "Selection3" [email from 3/15/24, 1:34 PM]
+        minmag = 19.0
+        excess = -0.75
+        maglim = 24.906 # corresponding to 5e-17 erg/s/cm^2 line flux
+        cc = [-60.5, 5.5, -0.125]
+        c12 = n419_mags - n501_mags
+        isel_a = (n419_mags <= maglim) & (n419_mags >= minmag)
+        isel_b = (d["FLUX_N501"] > 0) & (c12 <= excess)
+        isel_c = (d["FLUX_N501"] > 0) & (c12 <= cc[0] + cc[1] * n419_mags + cc[2] * n419_mags ** 2 - 0.4)
+        isel_d = (d["FLUX_N501"] > 0) & (c12 <= -16.375 + 0.6875 * n419_mags)
+        isel_e = (d["FLUX_N501"] > 0) & (c12 <= 17.27 - 0.75 * n419_mags)
+
+        sel = (isel_a) & (isel_b) & (isel_d) & (isel_e)
+        sel |= d["FLUX_N501"] <= 0
+
+        d = d[sel]
+
+        log.info("select {}/{} rows".format(sel.sum(), sel.size))
 
     # odin/n501
     if (img == "odin") & (band == "N501"):

--- a/py/desihiz/laelf_utils.py
+++ b/py/desihiz/laelf_utils.py
@@ -387,3 +387,34 @@ def get_filtmag(flam, filt_cen, filt_wid):
     mag = -48.60 - 2.5 * np.log10(filt_fnu.value)
 
     return mag
+
+
+def get_filtflam(mag, filt_cen, filt_wid):
+    """
+    Convert a AB magnitude to a flux for a filter.
+
+    Args:
+        mag: AB magnitude (float)
+        filt_cen: filter central wavelength in A (float)
+        filt_wid: filter width in A (float)
+
+    Returns:
+        flam: flux flimit in erg / s / cm2 / A (float)
+
+    Notes:
+        Credit to A. Dey.
+        This is the inverse of get_filtmag().
+    """
+
+    filt_fnu = 10. ** (-0.4 * (mag + 48.60))
+
+    filt_fnu *= u.erg / u.cm**2 / u.s / u.Hz
+
+    filt_lam = filt_fnu.to(
+        u.erg / u.cm**2 / u.s / u.angstrom,
+        equivalencies=u.spectral_density(filt_cen * u.angstrom),
+    )
+
+    flam = filt_lam.value * filt_wid
+
+    return flam


### PR DESCRIPTION
This PR adds/odifies the scripts to generate a photometric catalog that will be used for angular clustering analysis, for the {odin,N419,cosmos}, with replicating AD "Selection3" selection.

There is an additional script to generate the `odin-N419-cosmos-angfoot-{HSC,LS}.fits` healpix maps of the footprints covered by the two sets of Tractor catalogs.

