### PR TITLE
add n673 vi file

### DIFF
--- a/py/desihiz/hizmerge_io.py
+++ b/py/desihiz/hizmerge_io.py
@@ -422,6 +422,7 @@ def get_vi_fns(img):
         fns = [
             os.path.join(mydir, "FINAL_VI_ODIN_N501_20231012.fits"),
             os.path.join(mydir, "FINAL_VI_ODIN_N419_20231129.fits"),
+            os.path.join(mydir, "FINAL_VI_ODIN_N673_20240507.fits")
         ]
 
     if img == "suprime":


### PR DESCRIPTION
This PR adds VI information for 791 N673 spectra, from FINAL_VI_ODIN_N673_20240507.fits.