### PR TITLE
Simcoadd

### DIFF
--- a/bin/desi_simcoadd
+++ b/bin/desi_simcoadd
@@ -1,0 +1,322 @@
+#!/usr/bin/env python
+
+import os
+from time import time
+import numpy as np
+import fitsio
+from astropy.io import fits
+from astropy.table import vstack
+
+#
+from redrock.utils import native_endian
+from desiutil.log import get_logger
+from desispec.io import iotime
+from desispec.io.util import get_tempfilename
+
+#
+from desihiz.simcoadd_utils import (
+    get_outfn,
+    get_skies,
+    read_rrtemplate,
+    get_lsst_bands,
+    get_sim,
+    cameras,
+    fluxunits,
+)
+import multiprocessing
+from argparse import ArgumentParser
+
+
+# AR settings
+my_template_fn = os.path.join(
+    os.getenv("DESI_ROOT"),
+    "users",
+    "raichoor",
+    "laelbg",
+    "templates",
+    "lbg",
+    "rrtemplate-lbg.fits",
+)
+# my_sky_coadd_fn = os.path.join(os.getenv("DESI_ROOT"), "users", "raichoor", "laelbg", "daily", "healpix", "tertiary15-thru20221216", "skies-tertiary15-thru20221216.fits")
+my_sky_coadd_fn = os.path.join(
+    os.getenv("DESI_ROOT"),
+    "users",
+    "raichoor",
+    "laelbg",
+    "jura",
+    "healpix",
+    "skies-jura.fits",
+)
+np_rand_seed = 1234
+np.random.seed(np_rand_seed)
+
+log = get_logger()
+
+
+def parse():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--outdir", help="output folder (default=None)", type=str, default=None
+    )
+    parser.add_argument(
+        "--template_fn",
+        help="template file (default={})".format(my_template_fn),
+        type=str,
+        default=my_template_fn,
+    )
+    parser.add_argument(
+        "--template_row",
+        help="index of the template to pick (starting at 0); (default=3)",
+        type=int,
+        default=3,
+    )
+    parser.add_argument(
+        "--sky_coadd_fn",
+        help="coadd compiling sky fibers, used to pick the sky ivar from (default={})".format(
+            my_sky_coadd_fn
+        ),
+        type=str,
+        default=my_sky_coadd_fn,
+    )
+    parser.add_argument(
+        "--noise_method",
+        help="flux: pick FLUX values; ivar: draw a value from IVAR; ivarmed: draw a value from IVAR, and add an offset per camera; ivarmed2: draw a value from IVAR, and add an offset per half-camera (default=flux)",
+        type=str,
+        choices=["flux", "ivar", "ivarmed", "ivarmed2"],
+        default="flux",
+    )
+    parser.add_argument(
+        "--rescale_noise_cams",
+        help="comma-separated list of the cameras to rescale the rd noise (default=None)",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--rescale_noise_elecs",
+        help="comma-separated list of the rd noise electrons to rescale to (default=None)",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--n_per_zmag",
+        help="number of realizations per (z, mag) bin (default=50)",
+        type=int,
+        default=50,
+    )
+    parser.add_argument(
+        "--efftime_min",
+        help="EFFTIME_SPEC in minutes (default=120)",
+        type=int,
+        default=120,
+    )
+    parser.add_argument(
+        "--mag_band",
+        help="filter name used by load_filter()) (default=lsst2016-r)",
+        type=str,
+        default="lsst2016-r",
+    )
+    parser.add_argument(
+        "--mag_min", help="mag_min (default=22.5)", type=float, default=22.5
+    )
+    parser.add_argument(
+        "--mag_max", help="mag_max (default=25.0)", type=float, default=25.0
+    )
+    parser.add_argument(
+        "--mag_bin", help="mag_bin (default=0.5)", type=float, default=0.5
+    )
+    parser.add_argument("--z_min", help="z_min (default=1.5)", type=float, default=2.0)
+    parser.add_argument("--z_max", help="z_max (default=4.5)", type=float, default=4.0)
+    parser.add_argument("--z_bin", help="z_bin (default=0.1)", type=float, default=0.1)
+    parser.add_argument(
+        "--numproc",
+        help="number of concurrent processes to use; (default=1)",
+        type=int,
+        default=1,
+    )
+    parser.add_argument("--overwrite", action="store_true", help="overwrite output file?")
+    args = parser.parse_args()
+    # AR noise-rescaling is not relevant if using noise_method!=flux  I think...
+    if args.rescale_noise_cams is not None:
+        if args.noise_method != "flux":
+            msg = "for now, cannot set both args.noise_method!=flux and args.rescale_noise_cams"
+            log.error(msg)
+            raise ValueError(msg)
+        xs = np.array(args.rescale_noise_cams.split(","))
+        if np.in1d(xs, ["b", "r", "z"]).sum() != xs.size:
+            msg = "args.rescale_noise_cams have to be in b,r,z"
+            log.error(msg)
+            raise ValueError(msg)
+    for kwargs in args._get_kwargs():
+        log.info(kwargs)
+    return args
+
+
+def main():
+
+    # AR
+    args = parse()
+
+    # AR output file
+    outfn = get_outfn(
+        args.outdir,
+        args.template_fn,
+        args.template_row,
+        args.efftime_min,
+        args.noise_method,
+        args.rescale_noise_cams,
+        args.rescale_noise_elecs,
+        args.mag_min,
+        args.mag_max,
+        args.mag_bin,
+        args.z_min,
+        args.z_max,
+        args.z_bin,
+    )
+    log.info("outfn = {}".format(outfn))
+    if os.path.isfile(outfn):
+        if args.overwrite:
+            log.warning("{} already exists and will be overwritten".format(outfn))
+        else:
+            msg = "{} already exists and args.overwrite=False; exiting".format(outfn)
+            log.error(msg)
+            raise ValueError(msg)
+
+    # AR grid of objects
+    mag_grids = np.arange(
+        args.mag_min, args.mag_max + args.mag_bin, args.mag_bin
+    )  # .round(3)
+    mag_ngrid = len(mag_grids)
+    z_grids = np.arange(args.z_min, args.z_max + args.z_bin, args.z_bin)  # .round(3)
+    z_ngrid = len(z_grids)
+    #
+    nsim = mag_ngrid * z_ngrid * args.n_per_zmag
+    log.info("mag_grids = {}".format(mag_grids))
+    log.info("z_grids = {}".format(z_grids))
+    log.info("nsim = {}".format(nsim))
+
+    # AR sky: read the sky ivars
+    # AR sky: and rescale if asked
+    # AR TODO : if noise_method!=flux, the rescaling may not be relevant
+    sky = get_skies(
+        args.sky_coadd_fn,
+        args.efftime_min,
+        rescale_noise_cams=args.rescale_noise_cams,
+        rescale_noise_elecs=args.rescale_noise_elecs,
+    )
+
+    # AR template: read the template
+    rf_ws, rf_fs = read_rrtemplate(args.template_fn, args.template_row)
+
+    lsst_bands = get_lsst_bands()
+    # AR loop on mag, z
+    myargs = []
+    for mag in mag_grids:
+        for z in z_grids:
+            myargs.append(
+                [
+                    rf_ws,
+                    rf_fs,
+                    sky,
+                    z,
+                    mag,
+                    args.mag_band,
+                    lsst_bands,
+                    args.n_per_zmag,
+                    np.random.randint(1e9, size=1)[0],
+                    args.noise_method,
+                ]
+            )
+    pool = multiprocessing.Pool(processes=args.numproc)
+    log.info("start pool")
+    with pool:
+        myds = pool.starmap(get_sim, myargs)
+    log.info("pool done")
+
+    # AR stack
+    log.info("start stacking")
+    myd = {}
+    for ext in myds[0].keys():
+        if ext in ["FIBERMAP", "SCORES"]:
+            myd[ext] = vstack([myd_i[ext] for myd_i in myds])
+        elif (ext[2:] == "WAVELENGTH") | (ext[2:] == "RESCALE_VAR"):
+            myd[ext] = myds[0][ext]
+        else:
+            myd[ext] = np.vstack([myd_i[ext] for myd_i in myds])
+    myd["FIBERMAP"]["TARGETID"] = np.arange(nsim, dtype=int)
+    myd["SCORES"]["TARGETID"] = myd["FIBERMAP"]["TARGETID"]
+
+    # AR store into fits structure
+    hdus = fits.HDUList()
+    hdus.append(fits.convenience.table_to_hdu(myd["FIBERMAP"]))
+    efm = myd["FIBERMAP"].copy()
+    efm.meta["EXTNAME"] = "EXP_FIBERMAP"
+    hdus.append(fits.convenience.table_to_hdu(efm))
+    for camera in cameras:
+        for ext, ext_units, ext_type in zip(
+            [
+                "{}_WAVELENGTH".format(camera),
+                "{}_FLUX".format(camera),
+                "{}_IVAR".format(camera),
+                "{}_MASK".format(camera),
+                "{}_RESOLUTION".format(camera),
+                "{}_FLUX_NO_NOISE".format(camera),
+                "{}_RESCALE_VAR".format(camera),
+            ],
+            [
+                "Angstrom",
+                fluxunits.to_string(),
+                (fluxunits**-2).to_string(),
+                None,
+                None,
+                fluxunits.to_string(),
+                None,
+            ],
+            ["f8", "f4", "f4", "i4", "f4", "f4", "f4"],
+        ):
+            hdus.append(fits.ImageHDU(myd[ext].astype(ext_type), name=ext))
+            if ext_units is not None:
+                hdus[-1].header["BUNIT"] = ext_units
+    hdus.append(fits.convenience.table_to_hdu(myd["SCORES"]))
+    log.info("stacking done")
+
+    # AR write
+    log.info("start writing")
+    t0 = time()
+    tmpfile = get_tempfilename(outfn)
+    hdus.writeto(tmpfile, overwrite=True, checksum=True)
+    os.rename(tmpfile, outfn)
+    duration = time() - t0
+    # AR update primary header
+    F = fitsio.FITS(outfn, "rw")
+    for argname, key in [
+        ("template_fn", "TMPLFN"),
+        ("template_row", "TMPLROW"),
+        ("sky_coadd_fn", "SKYCOFN"),
+        ("noise_method", "NOISE"),
+        ("n_per_zmag", "NPERZMAG"),
+        ("efftime_min", "EFFTIME"),
+        ("mag_band", "MAGFILT"),
+        ("mag_min", "MAGMIN"),
+        ("mag_max", "MAGMAX"),
+        ("mag_bin", "MAGBIN"),
+        ("z_min", "ZMIN"),
+        ("z_max", "ZMAX"),
+        ("z_bin", "ZBIN"),
+        ("rescale_noise_cams", "RSCCAMS"),
+        ("rescale_noise_elecs", "RSELECS"),
+    ]:
+        F[0].write_key(key, eval("args.{}".format(argname)))
+    # AR add the whole command..
+    cmd = ["desi_simcoadd"]
+    for kwargs in args._get_kwargs():
+        log.info(kwargs)
+        if kwargs[1] is not None:
+            cmd += ["--{}".format(kwargs[0]), str(kwargs[1])]
+    F[0].write_key("RUNCMD", " ".join(cmd))
+    #
+    F.close()
+    log.info(iotime.format("write", outfn, duration))
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/desi_sky_extract
+++ b/bin/desi_sky_extract
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+
+import os
+from time import time
+import numpy as np
+from astropy.table import Table
+from astropy.io import fits
+from desispec.io import iotime
+from desispec.io.util import get_tempfilename
+from desiutil.log import get_logger
+from argparse import ArgumentParser
+
+
+log = get_logger()
+my_prognums = "15,23,26,37"
+my_prod = "jura"
+my_outfn = (
+    "/global/cfs/cdirs/desi/users/raichoor/laelbg/{}/healpix/skies-{}.fits".format(
+        my_prod, my_prod
+    )
+)
+
+
+def parse():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--outfn",
+        help="output file (default={})".format(my_outfn),
+        type=str,
+        default=my_outfn,
+    )
+    parser.add_argument(
+        "--prod",
+        help="spectro prod (default={})".format(my_prod),
+        type=str,
+        default=my_prod,
+    )
+    parser.add_argument(
+        "--prognums",
+        help="comma-separated list of the tertiary PROGNUMs to grab the sky fibers from (default={})".format(
+            my_prognums
+        ),
+        type=str,
+        default=my_prognums,
+    )
+    parser.add_argument(
+        "--wstuck", action="store_true", help="include stuck fibers in the sky fibers?"
+    )
+    args = parser.parse_args()
+    for kwargs in args._get_kwargs():
+        log.info(kwargs)
+    return args
+
+
+def main():
+
+    t0 = time()
+    args = parse()
+
+    prod_dir = os.path.join(os.getenv("DESI_ROOT"), "spectro", "redux", args.prod)
+
+    # tileids
+    fn = os.path.join(prod_dir, "tiles-{}.csv".format(args.prod))
+    d = Table.read(fn)
+    sel = np.zeros(len(d), dtype=bool)
+    for prognum in args.prognums.split(","):
+        sel |= d["FAFLAVOR"] == "specialtertiary{}".format(prognum)
+    tileids = d["TILEID"][sel]
+
+    # survey, program, pixel
+    fn = os.path.join(prod_dir, "healpix", "tilepix.fits")
+    d = Table.read(fn)
+    sel = np.in1d(d["TILEID"], tileids)
+    d = d[sel]
+
+    # unique coadd fns
+    fns = [
+        os.path.join(
+            prod_dir,
+            "healpix",
+            survey,
+            program,
+            str(pix // 100),
+            str(pix),
+            "coadd-{}-{}-{}.fits".format(survey, program, pix),
+        )
+        for survey, program, pix in zip(d["SURVEY"], d["PROGRAM"], d["HEALPIX"])
+    ]
+    fns = np.unique(fns)
+    print("found {} healpix files for {} tiles".format(len(fns), tileids.size))
+
+    for fn in fns:
+
+        h = fits.open(fn)
+
+        # targetids for our prognums
+        efm = h["EXP_FIBERMAP"].data
+        tids = efm["TARGETID"][np.in1d(efm["TILEID"], tileids)]
+
+        # sky targets
+        fm = h["FIBERMAP"].data
+        sel = np.in1d(fm["TARGETID"], tids)
+        sel &= fm["OBJTYPE"] == "SKY"
+        if not args.wstuck:
+            sel &= fm["TARGETID"] > 0
+            sel &= fm["COADD_FIBERSTATUS"] == 0
+        log.info("{}\t{} sky fibers".format(os.path.basename(fn), sel.sum()))
+        #
+        exts = [h[i].header["EXTNAME"] for i in range(1, len(h))]
+        exts = [
+            ext for ext in exts if ext[2:] != "WAVELENGTH"
+        ]  # AR do not touch WAVELENGTH
+        for ext in exts:
+            if ext in ["EXP_FIBERMAP"]:
+                sel_expfm = np.in1d(h[ext].data["TARGETID"], fm["TARGETID"][sel])
+                h[ext].data = h[ext].data[sel_expfm]
+            else:
+                h[ext].data = h[ext].data[sel]
+        #
+        if fn == fns[0]:
+            myh = h.copy()
+        else:
+            for ext in exts:
+                myh[ext].data = np.append(myh[ext].data, h[ext].data, axis=0)
+    log.info("all_coadds\t{} sky fibers".format(myh["FIBERMAP"].data.size))
+    myh[0].header["PROD"] = args.prod
+    myh[0].header["PRODDIR"] = prod_dir
+    myh[0].header["PROGNUMS"] = args.prognums
+    myh[0].header["WSTUCK"] = args.wstuck
+
+    myh.writeto(args.outfn, overwrite=True)
+    tmpfile = get_tempfilename(args.outfn)
+    myh.writeto(tmpfile, overwrite=True, checksum=True)
+    os.rename(tmpfile, args.outfn)
+    duration = time() - t0
+    log.info(iotime.format("write", args.outfn, duration))
+
+
+if __name__ == "__main__":
+    main()

--- a/py/desihiz/simcoadd_utils.py
+++ b/py/desihiz/simcoadd_utils.py
@@ -439,7 +439,7 @@ def get_lsst_bands():
     return ["u", "g", "r", "i", "z", "y"]
 
 
-def get_lsst_mags(ws, fs, bands, np_round=2):
+def get_lsst_mags(ws, fs, bands, year=2023, np_round=2):
     """
     Compute the lsst magnitudes for a given spectrum.
 
@@ -447,6 +447,7 @@ def get_lsst_mags(ws, fs, bands, np_round=2):
         ws: wavelengths (1d array of floats)
         fs: fluxes (1d array of floats)
         bands: list of lsst bands (list of str)
+        year (optional, defaults to 2023): speclite version of lsst filters (int)
         np_round (optional, defaults to 2): round mags to np_round digits (int)
 
     Returns:
@@ -455,7 +456,7 @@ def get_lsst_mags(ws, fs, bands, np_round=2):
     # AR template: add noise-free magnitudes
     mags = []
     for band in bands:
-        filter_response = load_filter("lsst2016-{}".format(band))
+        filter_response = load_filter("lsst{}-{}".format(year, band))
         # AR zero-padding spectrum so that it covers the filter response
         pad_ws, pad_fs = ws.copy(), fs.copy()
         if (pad_ws.min() > filter_response.wavelength.min()) | (

--- a/py/desihiz/simcoadd_utils.py
+++ b/py/desihiz/simcoadd_utils.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python
+
+import os
+import numpy as np
+from astropy.io import fits
+from astropy.table import Table, vstack
+from astropy import units
+from astropy.convolution import convolve, Box1DKernel
+
+#
+from speclite.filters import load_filter
+from redrock.utils import native_endian
+from desiutil.log import get_logger
+from desispec.io import read_frame, read_sky, read_flux_calibration
+from desispec.io.util import get_tempfilename
+
+#
+import matplotlib.pyplot as plt
+from matplotlib import gridspec
+
+# AR settings
+# np_rand_seed = 1234
+# np.random.seed(np_rand_seed)
+cameras = ["B", "R", "Z"]
+fluxunits = 1e-17 * units.erg / units.s / units.cm**2 / units.Angstrom
+_sky_coadd = None
+
+allowed_noise_method = ["flux", "ivar", "ivarmed", "ivarmed2"]
+
+log = get_logger()
+
+
+# AR output file
+def get_outfn(
+    outdir,
+    template_fn,
+    template_row,
+    efftime_min,
+    noise_method,
+    rescale_noise_cams,
+    rescale_noise_elecs,
+    mag_min,
+    mag_max,
+    mag_bin,
+    z_min,
+    z_max,
+    z_bin,
+):
+    assert noise_method in allowed_noise_method
+    template = (
+        os.path.basename(template_fn).replace("rrtemplate-", "").replace(".fits", "")
+    )
+    outfn = os.path.join(
+        outdir,
+        "coadd-{}-{}-{}min-{}mag{}-dmag{}-{}z{}-dz{}.fits".format(
+            template,
+            template_row,
+            efftime_min,
+            mag_min,
+            mag_max,
+            mag_bin,
+            z_min,
+            z_max,
+            z_bin,
+        ),
+    )
+    if noise_method != "flux":
+        outfn = outfn.replace(
+            "coadd-{}-{}".format(template, template_row),
+            "coadd-{}-{}-draw{}".format(template, template_row, noise_method),
+        )
+    if rescale_noise_cams is not None:
+        tmpstr = "-".join(
+            [
+                "{}{}e".format(cam, noise_elec)
+                for cam, noise_elec in zip(
+                    rescale_noise_cams.split(","), rescale_noise_elecs.split(",")
+                )
+            ]
+        )
+        outfn = outfn.replace(
+            "coadd-{}-{}".format(template, template_row),
+            "coadd-{}-{}-{}".format(template, template_row, tmpstr),
+        )
+    return outfn
+
+
+# AR read redrock template
+def read_rrtemplate(fn, row):
+    fx = fits.open(fn)
+    hdr = fx["BASIS_VECTORS"].header
+    ws = np.asarray(
+        hdr["CRVAL1"] + hdr["CDELT1"] * np.arange(hdr["NAXIS1"]), dtype=np.float64
+    )
+    if "LOGLAM" in hdr and hdr["LOGLAM"] != 0:
+        ws = 10**ws
+    fs = np.asarray(native_endian(fx["BASIS_VECTORS"].data), dtype=np.float64)
+    fs = fs[row, :]
+    return ws, fs
+
+
+# AR vector to rescale the read noise
+# AR discussion with Julien on Jan. 30th, 2023
+# AR https://desisurvey.slack.com/archives/D01MQB8D5JQ/p1675115375133969
+# AR we use here a typical dark exposure:
+# AR    NIGHT=20230128, EXPID=165078, EXPTIME=1051s, EFFTIME_SPEC=572s, SPEED=1.2)
+# AR the median speed for the dark survey so far is ~1.2
+# AR for now, we hard-code the use of rows=250-500, where both amplifiers have
+# AR    ~consistent read noise for a given camera
+def get_rescale_var_vector(camera, goal_rd_elec, outpng=None):
+    log.info("camera={}, goal_rd_elec={}".format(camera, goal_rd_elec))
+    # AR read
+    night, expid, petal = 20230128, 165078, 0
+    expdir = "/global/cfs/cdirs/desi/spectro/redux/daily/exposures/{}/{:08d}".format(
+        night, expid
+    )
+    sframe = read_frame(
+        os.path.join(expdir, "sframe-{}{}-{:08d}.fits.gz".format(camera, petal, expid))
+    )
+    sky = read_sky(
+        os.path.join(expdir, "sky-{}{}-{:08d}.fits.gz".format(camera, petal, expid))
+    )
+    fluxcal = read_flux_calibration(
+        os.path.join(
+            expdir, "fluxcalib-{}{}-{:08d}.fits.gz".format(camera, petal, expid)
+        )
+    )
+    cframe = read_frame(
+        os.path.join(expdir, "cframe-{}{}-{:08d}.fits.gz".format(camera, petal, expid))
+    )
+    # AR using AMPC, AMPD
+    rowmin, rowmax = 250, 500
+    obsrdn_c, obsrdn_d = sframe.meta["OBSRDNC"], sframe.meta["OBSRDND"]
+    std_rdnoise = np.round(0.5 * (obsrdn_c + obsrdn_d), 1)
+    log.info(
+        "obsrdn_c={:.1f}, obsrdn_d={:.1f} -> using std_rdnoise={}".format(
+            obsrdn_c, obsrdn_d, std_rdnoise
+        )
+    )
+    # AR select sky fibers
+    ii = np.where(cframe.fibermap["OBJTYPE"] == "SKY")[0]
+    ii = ii[(ii >= rowmin) & (ii <= rowmax)]
+    #
+    svar_true = np.median(1 / (sframe.ivar[ii] + (sframe.ivar[ii] == 0)), axis=0)
+    skyflux = np.median(sky.flux[ii], axis=0)
+    p1 = 1 / 0.8
+    sel = (svar_true > 0) & (skyflux > 0) & (skyflux < 400) & (svar_true < 400)
+    p0 = np.median((svar_true - p1 * skyflux)[sel]).round(0)
+    log.info("p0 = {}".format(p0))
+    #
+    # p0jguy = {"b":138, "r":66, "z":98}[camera]
+    cvar_true = np.median(
+        1 / (cframe.ivar[rowmin:rowmax] + (cframe.ivar[rowmin:rowmax] == 0)), axis=0
+    )
+    cvar_std = np.median(
+        (p0 + p1 * sky.flux[rowmin:rowmax]) / fluxcal.calib[rowmin:rowmax] ** 2, axis=0
+    )
+    # cvar_jguy = np.median((p0jguy + p1 * sky.flux[rowmin:rowmax]) / fluxcal.calib[rowmin:rowmax] ** 2, axis=0)
+    cvar_goalelec = np.median(
+        (p0 * (goal_rd_elec / std_rdnoise) ** 2 + p1 * sky.flux[rowmin:rowmax])
+        / fluxcal.calib[rowmin:rowmax] ** 2,
+        axis=0,
+    )
+    # cvar_goalelec_jguy = np.median((p0jguy * (goal_rd_elec / std_rdnoise) ** 2 + p1 * sky.flux[rowmin:rowmax]) / fluxcal.calib[rowmin:rowmax] ** 2, axis=0)
+    #
+    if outpng is not None:
+        fig = plt.subplots(figsize=(20, 5))
+        gs = gridspec.GridSpec(1, 3, wspace=0.3)
+        # AR calibrate_variance_model
+        ax = plt.subplot(gs[0])
+        ax.plot(skyflux, svar_true, ".", alpha=0.1)
+        ax.plot(
+            skyflux,
+            p0 + p1 * skyflux,
+            color="orange",
+            label="y = {} + {} * x".format(p0, p1),
+        )
+        # ax.plot(skyflux, p0jguy + p1 * skyflux, label="y = {} + {} * x".format(p0jguy, p1), color="g")
+        ax.set_title(
+            "{}{}-{:08d}: calibrate_variance_model".format(camera, petal, expid)
+        )
+        ax.set_xlabel("Median sky flux")
+        ax.set_ylabel("Median sframe var")
+        ax.set_xlim(0, 1000)
+        ax.set_ylim(0, 2000)
+        ax.grid()
+        ax.legend(loc=2)
+        # AR variance_model_vs_data
+        ax = plt.subplot(gs[1])
+        ax.plot(cframe.wave, cvar_true, label="variance in data")
+        ax.plot(
+            cframe.wave,
+            cvar_std,
+            color="orange",
+            alpha=0.5,
+            label="variance model (rdnoise+sky)",
+        )
+        # ax.plot(cframe.wave, cvar_jguy, alpha=0.5, label="variance model (rdnoise+sky) with p0={}".format(p0jguy), color="g")
+        ax.set_title("{}{}-{:08d}: variance_model_vs_data".format(camera, petal, expid))
+        ax.set_xlabel("Wavelength [A]")
+        ax.set_ylabel("Variance  [e^2/A]")
+        ax.grid()
+        ax.legend(loc=1)
+        # AR variance_ratio_vs_rdnoise
+        ax = plt.subplot(gs[2])
+        ax.plot(
+            cframe.wave,
+            cvar_goalelec / cvar_std,
+            color="orange",
+            label="readnoise from {} to {} elec/pix".format(std_rdnoise, goal_rd_elec),
+        )
+        # ax.plot(cframe.wave, cvar_goalelec_jguy / cvar_std, alpha=0.5, label="readnoise from {} to {} elec/pix with p0={}".format(std_rdnoise, goal_rd_elec, p0jguy), color="g")
+        ax.set_title(
+            "{}{}-{:08d}: variance_ratio_vs_rdnoise".format(camera, petal, expid)
+        )
+        ax.set_xlabel("Wavelength [A]")
+        ax.set_ylabel("Variance (or required exposure time) ratio")
+        ax.grid()
+        ax.legend(loc=2)
+        #
+        plt.savefig(outpng, bbox_inches="tight")
+        plt.close()
+    #
+    return cframe.wave, cvar_goalelec / cvar_std
+
+
+def read_sky_coadd(fn):
+    global _sky_coadd
+    if _sky_coadd is not None:
+        log.info("using cached {}".format(fn))
+        return _sky_coadd
+    else:
+        log.info("reading {}".format(fn))
+        _sky_coadd = fits.open(fn)
+    return _sky_coadd
+
+
+# AR select sky fibers in the correct efftime
+def get_skies(
+    sky_coadd_fn,
+    efftime_min,
+    relative_tolerance=0.1,
+    rescale_noise_cams=None,
+    rescale_noise_elecs=None,
+):
+    h = read_sky_coadd(sky_coadd_fn)
+    sel = (
+        np.abs(12.15 * h["SCORES"].data["TSNR2_LRG"] / 60 / efftime_min - 1)
+        < relative_tolerance
+    )
+    txt = "gathered {} sky fibers with abs(efftime_min/{} - 1) < {}".format(
+        sel.sum(), efftime_min, relative_tolerance
+    )
+    if sel.sum() == 0:
+        log.warning(txt)
+    else:
+        log.info(txt)
+    sky = {}
+    for key in [
+        "TARGETID",
+        "TSNR2_BGS",
+        "TSNR2_LRG",
+        "TSNR2_ELG",
+        "TSNR2_LYA",
+    ]:
+        sky[key] = h["SCORES"].data[key][sel]
+    for camera in cameras:
+        sky["{}_WAVELENGTH".format(camera)] = h["{}_WAVELENGTH".format(camera)].data
+        for ext in [
+            "{}_FLUX".format(camera),
+            "{}_IVAR".format(camera),
+            "{}_RESOLUTION".format(camera),
+        ]:
+            sky[ext] = h[ext].data[sel]
+    # AR sky: rescale?
+    # AR TODO : if noise_method!=flux, the rescaling may not be relevant
+    for camera in cameras:
+        sky["{}_RESCALE_VAR".format(camera)] = np.ones_like(
+            sky["{}_WAVELENGTH".format(camera)]
+        )
+    if rescale_noise_cams is not None:
+        for camera, goal_rd_elec in zip(
+            rescale_noise_cams.split(","),
+            rescale_noise_elecs.split(","),
+        ):
+            (
+                rescale_ws,
+                sky["{}_RESCALE_VAR".format(camera.upper())],
+            ) = get_rescale_var_vector(camera, int(goal_rd_elec))
+            assert np.all(rescale_ws == sky["{}_WAVELENGTH".format(camera.upper())])
+    for camera in cameras:
+        sky["{}_FLUX".format(camera)] *= sky["{}_RESCALE_VAR".format(camera)] ** 0.5
+        sky["{}_IVAR".format(camera)] /= sky["{}_RESCALE_VAR".format(camera)]
+    # AR after potentially rescaling, now compute the median values
+    # AR    setting flux=nan for ivar=0, then using np.nanmedian()...
+    for camera in cameras:
+        nw = len(sky["{}_WAVELENGTH".format(camera)])
+        fluxes, ivars = (
+            sky["{}_FLUX".format(camera)].copy(),
+            sky["{}_IVAR".format(camera)].copy(),
+        )
+        fluxes[ivars == 0] = np.nan
+        for key, imin, imax in zip(
+            [
+                "SKY_{}_MEDIAN_FLUX".format(camera),
+                "SKY_{}_BLUE_MEDIAN_FLUX".format(camera),
+                "SKY_{}_RED_MEDIAN_FLUX".format(camera),
+            ],
+            [0, 0, nw // 2],
+            [nw, nw // 2, nw],
+        ):
+            sky[key] = np.nanmedian(fluxes[:, imin:imax], axis=1)
+    #
+    return sky
+
+
+# AR similar to desispec.fluxcalibration.normalize_templates
+# AR but handles padding
+# AR and possibility to use other filter..
+def rescale_template2mag(ws, fs, mag, mag_band, verbose=False):
+    # AR filter
+    filter_response = load_filter(mag_band)
+    # AR zero-padding spectrum so that it covers the filter response
+    pad_ws, pad_fs = ws.copy(), fs.copy()
+    if (pad_ws.min() > filter_response.wavelength.min()) | (
+        pad_ws.max() < filter_response.wavelength.max()
+    ):
+        pad_ws, pad_fs = filter_response.pad_spectrum(pad_fs, pad_ws, method="zero")
+    # AR now scale
+    orig_mag = filter_response.get_ab_magnitude(pad_fs * fluxunits, pad_ws)
+    scalefac = 10 ** ((orig_mag - mag) / 2.5)
+    rescale_fs = fs * scalefac
+    if verbose:
+        log.info(
+            "orig_mag={:.1f}\tmag={:.1f}\tscalefac={:.2f}".format(
+                orig_mag, mag, scalefac
+            )
+        )
+    return rescale_fs
+
+
+def get_lsst_bands():
+    return ["u", "g", "r", "i", "z", "y"]
+
+
+def get_lsst_mags(ws, fs, bands, np_round=2):
+    # AR template: add noise-free magnitudes
+    mags = []
+    for band in bands:
+        filter_response = load_filter("lsst2016-{}".format(band))
+        # AR zero-padding spectrum so that it covers the filter response
+        pad_ws, pad_fs = ws.copy(), fs.copy()
+        if (pad_ws.min() > filter_response.wavelength.min()) | (
+            pad_ws.max() < filter_response.wavelength.max()
+        ):
+            pad_fs, pad_ws = filter_response.pad_spectrum(pad_fs, pad_ws, method="zero")
+        # AR get the mag
+        mag = filter_response.get_ab_magnitude(pad_fs * fluxunits, pad_ws)
+        mags.append(mag.round(np_round))
+    return mags
+
+
+def template_rf2z(rf_ws, rf_fs, cameras_ws, z, mag, mag_band):
+    # AR first rescale to the requested magnitude
+    ws = (1 + z) * rf_ws
+    fs = rescale_template2mag(ws, rf_fs, mag, mag_band)
+    # AR then interpolate for each camera
+    cameras_fs = {}
+    for camera in cameras_ws:
+        cameras_fs[camera] = np.interp(cameras_ws[camera], ws, fs, left=0, right=0)
+    return cameras_fs
+
+
+def get_tsnr2_truez(
+    myd, zs, lya_rf_wmin=1215.7 - 5, lya_rf_wmax=1215.7 + 5, wdelta=0.8, smooth=100
+):
+    #
+    smoothing = np.ceil(smooth / wdelta).astype(int)
+    #
+    nspec = len(zs)
+    mydout = {}
+    for suffix in ["TRUEZLYA", "TRUEZNOLYA"]:
+        keys = ["TSNR2_{}".format(suffix)]
+        keys += ["TSNR2_{}_{}".format(suffix, camera) for camera in cameras]
+        for key in keys:
+            mydout[key] = np.zeros(nspec)
+    for camera in cameras:
+        for i in range(nspec):
+            # AR nulling the lya region for computing the smoothed spectrum
+            lya_wmin, lya_wmax = (1 + zs[i]) * lya_rf_wmin, (1 + zs[i]) * lya_rf_wmax
+            ws = myd["{}_WAVELENGTH".format(camera)]
+            sel = (ws > lya_wmin) & (ws < lya_wmax)
+            fs_i = myd["{}_FLUX".format(camera)][i]
+            fs_nolya_i = fs_i.copy()
+            fs_nolya_i[sel] = np.nan
+            smfs_i = convolve(fs_nolya_i, Box1DKernel(smoothing), boundary="extend")
+            dfs_i = fs_i - smfs_i
+            if sel.sum() > 0:
+                mydout["TSNR2_TRUEZLYA_{}".format(camera)][i] = (
+                    dfs_i[sel] ** 2 * myd["{}_IVAR".format(camera)][i, sel]
+                ).mean()
+            mydout["TSNR2_TRUEZNOLYA_{}".format(camera)][i] = (
+                dfs_i[~sel] ** 2 * myd["{}_IVAR".format(camera)][i, ~sel]
+            ).mean()
+        for suffix in ["TRUEZLYA", "TRUEZNOLYA"]:
+            mydout["TSNR2_{}".format(suffix)] += mydout[
+                "TSNR2_{}_{}".format(suffix, camera)
+            ]
+    return mydout
+
+
+def get_sim(
+    rf_ws, rf_fs, sky, z, mag, mag_band, lsst_bands, nsim, np_rand_seed, noise_method
+):
+
+    np.random.seed(np_rand_seed)
+    nsky = sky["{}_FLUX".format(cameras[0])].shape[0]
+    ii_sky = np.random.choice(nsky, size=nsim, replace=True)
+
+    #
+    myd = {}
+    myd["FIBERMAP"] = Table()
+    myd["FIBERMAP"].meta["EXTNAME"] = "FIBERMAP"
+    myd["FIBERMAP"]["TRUE_Z"] = z + np.zeros(nsim)
+    # AR add columns required by redrock
+    myd["FIBERMAP"]["COADD_FIBERSTATUS"] = 0
+    myd["FIBERMAP"]["OBJTYPE"] = "TGT"
+    # AR add columns required by emlinefit
+    # AR pick a location with low ebv (=0.0024)
+    # AR so that when dust is removed, it is negligible
+    # AR (rather than touching the code...)
+    myd["FIBERMAP"]["TARGET_RA"], myd["FIBERMAP"]["TARGET_DEC"] = 206.56, 57.07
+    # AR scores
+    myd["SCORES"] = Table()
+    myd["SCORES"].meta["EXTNAME"] = "SCORES"
+    myd["SCORES"]["RANDSEED"] = np_rand_seed + np.zeros(nsim, dtype=int)
+
+    # AR template: redshift + mag-rescale
+    cameras_ws = {camera: sky["{}_WAVELENGTH".format(camera)] for camera in cameras}
+    template_fs = template_rf2z(rf_ws, rf_fs, cameras_ws, z, mag, mag_band)
+
+    # AR lsst mags (first re-generate a single spectrum...)
+    tmp_ws, tmp_fs = np.zeros(0), np.zeros(0)
+    for camera in cameras:
+        tmp_ws = np.append(tmp_ws, cameras_ws[camera])
+        tmp_fs = np.append(tmp_fs, template_fs[camera])
+    tmp_ws, ii = np.unique(tmp_ws, return_index=True)
+    tmp_fs = tmp_fs[ii]
+    #
+    mags = get_lsst_mags(tmp_ws, tmp_fs, lsst_bands)
+    log.info(
+        "mag={}\tz={}:\t{}".format(
+            mag,
+            z,
+            ",".join(
+                ["{}={:.1f}".format(band, mag) for band, mag in zip(lsst_bands, mags)]
+            ),
+        )
+    )
+    myd["FIBERMAP"].meta["FILTERS"] = ",".join(lsst_bands)
+    for band, mag in zip(lsst_bands, mags):
+        myd["FIBERMAP"]["MAG_{}".format(band.upper())] = mag
+
+    # AR template: add noise from a randomly picked sky fiber
+    myd["FIBERMAP"]["SKY_TARGETID"] = sky["TARGETID"][ii_sky]
+    for camera in cameras:
+        for key in [
+            "SKY_{}_MEDIAN_FLUX".format(camera),
+            "SKY_{}_BLUE_MEDIAN_FLUX".format(camera),
+            "SKY_{}_RED_MEDIAN_FLUX".format(camera),
+        ]:
+            myd["FIBERMAP"][key] = sky[key][ii_sky]
+
+    # AR columns
+    for key in [
+        "TSNR2_BGS",
+        "TSNR2_LRG",
+        "TSNR2_ELG",
+        "TSNR2_LYA",
+    ]:
+        myd["SCORES"][key] = sky[key][ii_sky]
+
+    for camera in cameras:
+        # AR wavelengths
+        myd["{}_WAVELENGTH".format(camera)] = sky["{}_WAVELENGTH".format(camera)]
+        nw = sky["{}_WAVELENGTH".format(camera)].size
+        # AR ivar, resolution (simple copies)
+        for ext in [
+            "{}_IVAR".format(camera),
+            "{}_RESOLUTION".format(camera),
+        ]:
+            myd[ext] = sky[ext][ii_sky]
+        # AR mask
+        myd["{}_MASK".format(camera)] = np.zeros((nsim, nw))
+        # AR flux with no noise
+        myd["{}_FLUX_NO_NOISE".format(camera)] = np.broadcast_to(
+            template_fs[camera], (nsim, nw)
+        )
+        # AR flux with noise
+        if noise_method == "flux":
+            efs = sky["{}_FLUX".format(camera)][ii_sky]
+        # AR
+        elif noise_method in ["ivar", "ivarmed", "ivarmed2"]:
+            efs = np.zeros_like(sky["{}_FLUX".format(camera)][ii_sky])
+            for i, i_sky in enumerate(ii_sky):
+                flux_i = sky["{}_FLUX".format(camera)][i_sky]
+                ivar_i = sky["{}_IVAR".format(camera)][
+                    i_sky
+                ]  # AR same as myd["{}_IVAR".format(camera)][i]..
+                # AR pick a value from IVAR
+                # AR set to 0 where IVAR=0..
+                err_i = 0.0 * ivar_i
+                sel = ivar_i > 0
+                err_i[sel] = ivar_i[sel] ** -0.5
+                efs[i] = np.random.normal(size=nw) * err_i
+                # AR add an offset, using median value
+                # AR maybe it can be done faster with doing that outside of the for i loop...
+                if noise_method == "ivarmed":
+                    efs[i] += myd["FIBERMAP"]["SKY_{}_MEDIAN_FLUX".format(camera)][i]
+                if noise_method == "ivarmed2":
+                    for key, imin, imax in zip(
+                        [
+                            "SKY_{}_BLUE_MEDIAN_FLUX".format(camera),
+                            "SKY_{}_RED_MEDIAN_FLUX".format(camera),
+                        ],
+                        [0, nw // 2],
+                        [nw // 2, nw],
+                    ):
+                        efs[i, imin:imax] += myd["FIBERMAP"][key][i]
+        else:
+            msg = "noise_method={} not allowed".format(noise_method)
+            log.error(msg)
+            raise ValueError(msg)
+        myd["{}_FLUX".format(camera)] = myd["{}_FLUX_NO_NOISE".format(camera)] + efs
+        myd["{}_RESCALE_VAR".format(camera)] = sky["{}_RESCALE_VAR".format(camera)]
+
+    # AR
+    tsnr2 = get_tsnr2_truez(myd, z + np.zeros(nsim))
+    for key in tsnr2.keys():
+        myd["SCORES"][key] = tsnr2[key]
+    return myd
+
+
+def create_rrtemplate_with_z(template_fn, outdir, zmin, zmax):
+    log.info("read {}".format(template_fn))
+    # AR open template (with no REDSHIFTS extension)
+    h = fits.open(template_fn)
+    # AR add a redshift grid
+    zs = 10 ** np.arange(np.log10(1 + zmin), np.log10(1 + zmax), 5e-4) - 1
+    log.info("redshift grid: {} values within {} and {}".format(zs.size, zmin, zmax))
+    h.append(fits.ImageHDU(data=zs))
+    h[-1].header["EXTNAME"] = "REDSHIFTS"
+    # AR create folder
+    if not os.path.isdir(outdir):
+        log.info("create {}".format(outdir))
+        os.makedirs(outdir, exist_ok=True)
+    # AR write
+    outfn = os.path.join(outdir, os.path.basename(template_fn))
+    log.info("write to {}".format(outfn))
+    h.writeto(outfn, overwrite=True)

--- a/py/desihiz/simcoadd_utils.py
+++ b/py/desihiz/simcoadd_utils.py
@@ -311,7 +311,14 @@ def get_skies(
         rescale_noise_elecs (optional, defaults to None): array of goal read noise, in electron units (list of float)
 
     Returns:
-        The "sky structure" (see read_sky_coadd())
+        sky, a dictionary with the following keys:
+            TARGETID, TSNR2_{BGS,LRG,ELG,LYA}: propagated from sky_coadd_fn["SCORES"]
+            {camera}_WAVELENGTH: copied from sky_coadd_fn
+            {camera}_FLUX: sky_coadd_fn[{camera}_FLUX] * {camera}_RESCALE_VAR ** 0.5
+            {camera}_IVAR: sky_coadd_fn[{camera}_IVAR] / {camera}_RESCALE_VAR
+            {camera}_RESOLUTION: copied from sky_coadd_fn
+            {camera}_RESCALE_VAR: vector used to rescale {camera}_VAR
+            SKY_{camera}_MEDIAN_FLUX, SKY_{camera}_BLUE_MEDIAN_FLUX, SKY_{camera}_RED_MEDIAN_FLUX: median values of the *rescaled* sky flux over the camera, the half-bluest pixels of the camera, and the half-reddest pixels of the camera
 
     Notes:
         We use for the effective time 12.15 * TSNR2_LRG / 60.
@@ -578,8 +585,19 @@ def get_sim(
 
     Returns:
         myd: dictionary with various entries:
-            FIBERMAP: a fibermap-like Table, with additional custom columns
-            SCORES: a scores-like Table, with additional values computed with get_tsnr2_truez()
+            FIBERMAP: a fibermap-like Table, with the following columns:
+                TRUE_Z: input z
+                COADD_FIBERSTATUS: 0
+                OBJTYPE: "TGT"
+                TARGET_RA, TARGET_DEC: 206.56, 57.07 (coordinate with a low EBV)
+                MAG_{band} for band in lsstbands: magnitudes in the lsst bands
+                SKY_TARGETID: TARGETID of the sky coadd used for adding noise
+                SKY_{camera}_MEDIAN_FLUX, SKY_{camera}_BLUE_MEDIAN_FLUX, SKY_{camera}_RED_MEDIAN_FLUX: median values of the *rescaled* sky flux over the camera, the half-bluest pixels of the camera, and the half-reddest pixels of the camera
+            SCORES: a scores-like Table, with the following columns:
+                RANDSEED: numpy random seed
+                TSNR2_{BGS,LRG,ELG,LYA}: values propagated from the sky coadd
+                TSNR2_TRUEZLYA, TSNR2_TRUEZLYA_{B,R,Z}: output from get_tsnr2_truez()
+                TSNR2_TRUEZNOLYA, TSNR2_TRUEZNOLYA_{B,R,Z}: output from get_tsnr2_truez()
             {camera}_WAVELENGTH: wavelength array (nwave)
             {camera}_IVAR: ivar array (nsim, nwave), from the sky input
             {camera}_RESOLUTION: copy of the values from the sky input


### PR DESCRIPTION
This PR adds scripts to generate spectra based on redrock templates with realistic noise, using information from sky fibers.
This version works on a grid of (redshifts, magnitudes).

# Gather sky spectra (`desi_sky_extract` script)

First, `desi_sky_extract` gathers the data sky fiber coadds:
- from a production (default=`jura`),
- restricting to some tertiary programs (default=`15,23,26,37`, i.e. LAE/LBG programs -- all dark conditions, with fairly large coadded times),
- using the healpix coadds.
```
usage: desi_sky_extract [-h] [--outfn OUTFN] [--prod PROD] [--prognums PROGNUMS] [--wstuck]
```
By default, I exclude the stuck-sky fibers, as I am less certain of how to deal / clean those.
It generates this file -- which one could just use to work with:
```
/global/cfs/cdirs/desi/users/raichoor/laelbg/jura/healpix/skies-jura.fits
```
It contains 4,224 sky spectra, with the following `EFFTIME_SPEC = 12.15 * TSNR2_LRG` distribution:
![tmp](https://github.com/user-attachments/assets/b309c570-9144-458d-b4b5-3d3eff82d393)

# Generate templates with realistic noise

## `sim_coadd` script
Then, if ones want to simulate e.g. a `EFFTIME_SPEC = 120min` observation with DESI, the `sim_coadd` script will pick a sky fiber with such an `EFFTIME_SPEC`, and add the relevant noise to a redrock template for a grid of redshifts and magnitudes:
```
usage: desi_simcoadd [-h] [--outdir OUTDIR] [--template_fn TEMPLATE_FN] [--template_row TEMPLATE_ROW] [--sky_coadd_fn SKY_COADD_FN]
                     [--noise_method {flux,ivar,ivarmed,ivarmed2}] [--rescale_noise_cams RESCALE_NOISE_CAMS] [--rescale_noise_elecs RESCALE_NOISE_ELECS]
                     [--n_per_zmag N_PER_ZMAG] [--efftime_min EFFTIME_MIN] [--mag_band MAG_BAND] [--mag_min MAG_MIN] [--mag_max MAG_MAX] [--mag_bin MAG_BIN]
                     [--z_min Z_MIN] [--z_max Z_MAX] [--z_bin Z_BIN] [--numproc NUMPROC] [--overwrite]
```
## Redrock template (`template_fn`, `template_row`)
The code starts from a redrock template.
The expected format is a (nwave, ntemplate) 2d-array in a `BASIS_VECTORS` extension.
See the `simcoadd_utils.read_rrtemplate()` function.
The `template_row` argument refers to the template stored in the zero-indexed row in that extension.

## Add realistic noise (`noise_method`)

Then, if ones want to simulate e.g. a `EFFTIME_SPEC = 120min` observation with DESI, the principle is to pick a sky fiber with such an `EFFTIME_SPEC`, and add the relevant noise to a redrock template.
There are four possible ways to add noise, using the sky FLUX and IVAR arrays:
- `flux` (default): pick FLUX values;
- `ivar`: draw a value from IVAR;
- `ivarmed`: draw a value from IVAR, and add an offset per camera;
- `ivarmed2`: draw a value from IVAR, and add an offset per half-camera.

As one can see from the data, there are lots of fibers with short exposure times, and less with higher-exposure times.
This is because we usually perform observations in 15min-exposures, then coadd.
Only fibers used for sky in several exposures will thus get large exposure times.
A consequence is that, if one wants to generate e.g. `EFFTIME_SPEC = 4h` noise, only few tens of sky fibers are available; that can be a limitation, depending on the chosen method; e.g. the `flux` method, could end up adding the same noise in several realisations.

## Rescaling the read-noise (`rescale_noise`)
The code allows one to rescale the read-noise for one or several cameras.
For instance, one could choose to rescale the b-camera read-noise to 1 electron.
This is handled in the `simcoadd_utils.get_rescale_var_vector()` function.

## Redshift and magnitude values
The current code will generate templates redshifted to a grid of redshifts values, and scaled to a grid of magnitude values (for a given band).
And for each (z, mag) grid point, it will generate `n_per_zmag` spectra (with -- hopefully different -- noise realisations).
The photometry is done with the LSST (2023) passbands.
A soon-to-come PR will allows one to pick continuous values of redshifts and/or magnitudes.