### PR TITLE
Simcoadd: allow continuous (z, mag) values

### DIFF
--- a/bin/desi_simcoadd
+++ b/bin/desi_simcoadd
@@ -127,15 +127,29 @@ def parse():
     parser.add_argument("--z_min", help="z_min (default=1.5)", type=float, default=2.0)
     parser.add_argument("--z_max", help="z_max (default=4.5)", type=float, default=4.0)
     parser.add_argument("--z_bin", help="z_bin (default=0.1)", type=float, default=0.1)
-    parser.add_argument("--z_pick", help="pick z values on a grid, or in continuous values? (default=grid)", type=str, choices=["grid", "continuous"], default="grid")
-    parser.add_argument("--mag_pick", help="pick mag values on a grid, or in continuous values? (default=grid)", type=str, choices=["grid", "continuous"], default="grid")
+    parser.add_argument(
+        "--z_pick",
+        help="pick z values on a grid, or in continuous values? (default=grid)",
+        type=str,
+        choices=["grid", "continuous"],
+        default="grid",
+    )
+    parser.add_argument(
+        "--mag_pick",
+        help="pick mag values on a grid, or in continuous values? (default=grid)",
+        type=str,
+        choices=["grid", "continuous"],
+        default="grid",
+    )
     parser.add_argument(
         "--numproc",
         help="number of concurrent processes to use; (default=1)",
         type=int,
         default=1,
     )
-    parser.add_argument("--overwrite", action="store_true", help="overwrite output file?")
+    parser.add_argument(
+        "--overwrite", action="store_true", help="overwrite output file?"
+    )
     args = parser.parse_args()
     # AR noise-rescaling is not relevant if using noise_method!=flux  I think...
     if args.rescale_noise_cams is not None:
@@ -217,14 +231,18 @@ def main():
             else:
                 if im == len(mag_grids) - 1:
                     continue
-                mags = np.random.uniform(low=mag_grids[im], high=mag_grids[im+1], size=args.n_per_zmag)
+                mags = np.random.uniform(
+                    low=mag_grids[im], high=mag_grids[im + 1], size=args.n_per_zmag
+                )
             if args.z_pick == "grid":
                 zs = z_grids[iz] + np.zeros(args.n_per_zmag)
             else:
                 if iz == len(z_grids) - 1:
                     continue
                 else:
-                    zs = np.random.uniform(low=z_grids[iz], high=z_grids[iz+1], size=args.n_per_zmag)
+                    zs = np.random.uniform(
+                        low=z_grids[iz], high=z_grids[iz + 1], size=args.n_per_zmag
+                    )
             myargs.append(
                 [
                     rf_ws,

--- a/bin/desi_simcoadd
+++ b/bin/desi_simcoadd
@@ -127,6 +127,8 @@ def parse():
     parser.add_argument("--z_min", help="z_min (default=1.5)", type=float, default=2.0)
     parser.add_argument("--z_max", help="z_max (default=4.5)", type=float, default=4.0)
     parser.add_argument("--z_bin", help="z_bin (default=0.1)", type=float, default=0.1)
+    parser.add_argument("--z_pick", help="pick z values on a grid, or in continuous values? (default=grid)", type=str, choices=["grid", "continuous"], default="grid")
+    parser.add_argument("--mag_pick", help="pick mag values on a grid, or in continuous values? (default=grid)", type=str, choices=["grid", "continuous"], default="grid")
     parser.add_argument(
         "--numproc",
         help="number of concurrent processes to use; (default=1)",
@@ -189,10 +191,8 @@ def main():
     z_grids = np.arange(args.z_min, args.z_max + args.z_bin, args.z_bin)  # .round(3)
     z_ngrid = len(z_grids)
     #
-    nsim = mag_ngrid * z_ngrid * args.n_per_zmag
     log.info("mag_grids = {}".format(mag_grids))
     log.info("z_grids = {}".format(z_grids))
-    log.info("nsim = {}".format(nsim))
 
     # AR sky: read the sky ivars
     # AR sky: and rescale if asked
@@ -210,18 +210,30 @@ def main():
     lsst_bands = get_lsst_bands()
     # AR loop on mag, z
     myargs = []
-    for mag in mag_grids:
-        for z in z_grids:
+    for im in range(len(mag_grids)):
+        for iz in range(len(z_grids)):
+            if args.mag_pick == "grid":
+                mags = mag_grids[im] + np.zeros(args.n_per_zmag)
+            else:
+                if im == len(mag_grids) - 1:
+                    continue
+                mags = np.random.uniform(low=mag_grids[im], high=mag_grids[im+1], size=args.n_per_zmag)
+            if args.z_pick == "grid":
+                zs = z_grids[iz] + np.zeros(args.n_per_zmag)
+            else:
+                if iz == len(z_grids) - 1:
+                    continue
+                else:
+                    zs = np.random.uniform(low=z_grids[iz], high=z_grids[iz+1], size=args.n_per_zmag)
             myargs.append(
                 [
                     rf_ws,
                     rf_fs,
                     sky,
-                    z,
-                    mag,
+                    zs,
+                    mags,
                     args.mag_band,
                     lsst_bands,
-                    args.n_per_zmag,
                     np.random.randint(1e9, size=1)[0],
                     args.noise_method,
                 ]
@@ -242,7 +254,7 @@ def main():
             myd[ext] = myds[0][ext]
         else:
             myd[ext] = np.vstack([myd_i[ext] for myd_i in myds])
-    myd["FIBERMAP"]["TARGETID"] = np.arange(nsim, dtype=int)
+    myd["FIBERMAP"]["TARGETID"] = np.arange(len(myd["FIBERMAP"]), dtype=int)
     myd["SCORES"]["TARGETID"] = myd["FIBERMAP"]["TARGETID"]
 
     # AR store into fits structure

--- a/bin/desi_simcoadd
+++ b/bin/desi_simcoadd
@@ -198,15 +198,13 @@ def main():
             raise ValueError(msg)
 
     # AR grid of objects
-    mag_grids = np.arange(
+    grid_mags = np.arange(
         args.mag_min, args.mag_max + args.mag_bin, args.mag_bin
     )  # .round(3)
-    mag_ngrid = len(mag_grids)
-    z_grids = np.arange(args.z_min, args.z_max + args.z_bin, args.z_bin)  # .round(3)
-    z_ngrid = len(z_grids)
+    grid_zs = np.arange(args.z_min, args.z_max + args.z_bin, args.z_bin)  # .round(3)
     #
-    log.info("mag_grids = {}".format(mag_grids))
-    log.info("z_grids = {}".format(z_grids))
+    log.info("grid_mags = {}".format(grid_mags))
+    log.info("grid_zs = {}".format(grid_zs))
 
     # AR sky: read the sky ivars
     # AR sky: and rescale if asked
@@ -224,24 +222,24 @@ def main():
     lsst_bands = get_lsst_bands()
     # AR loop on mag, z
     myargs = []
-    for im in range(len(mag_grids)):
-        for iz in range(len(z_grids)):
+    for im in range(len(grid_mags)):
+        for iz in range(len(grid_zs)):
             if args.mag_pick == "grid":
-                mags = mag_grids[im] + np.zeros(args.n_per_zmag)
+                mags = grid_mags[im] + np.zeros(args.n_per_zmag)
             else:
-                if im == len(mag_grids) - 1:
+                if im == len(grid_mags) - 1:
                     continue
                 mags = np.random.uniform(
-                    low=mag_grids[im], high=mag_grids[im + 1], size=args.n_per_zmag
+                    low=grid_mags[im], high=grid_mags[im + 1], size=args.n_per_zmag
                 )
             if args.z_pick == "grid":
-                zs = z_grids[iz] + np.zeros(args.n_per_zmag)
+                zs = grid_zs[iz] + np.zeros(args.n_per_zmag)
             else:
-                if iz == len(z_grids) - 1:
+                if iz == len(grid_zs) - 1:
                     continue
                 else:
                     zs = np.random.uniform(
-                        low=z_grids[iz], high=z_grids[iz + 1], size=args.n_per_zmag
+                        low=grid_zs[iz], high=grid_zs[iz + 1], size=args.n_per_zmag
                     )
             myargs.append(
                 [

--- a/py/desihiz/simcoadd_utils.py
+++ b/py/desihiz/simcoadd_utils.py
@@ -657,7 +657,9 @@ def get_sim(
     for z, mag in zip(zs, mags):
         tmp_fs = template_rf2z(rf_ws, rf_fs, cameras_ws, z, mag, mag_band)
         for camera in cameras:
-            template_fs[camera] = np.append(template_fs[camera], tmp_fs[camera].reshape(1, nws[camera]), axis=0)
+            template_fs[camera] = np.append(
+                template_fs[camera], tmp_fs[camera].reshape(1, nws[camera]), axis=0
+            )
 
     # AR lsst mags
     myd["FIBERMAP"].meta["FILTERS"] = ",".join(lsst_bands)
@@ -668,7 +670,9 @@ def get_sim(
             tmp_ws, ii = np.unique(tmp_ws, return_index=True)
         tmp_fs = np.hstack([template_fs[camera] for camera in cameras])
         tmp_fs = tmp_fs[:, ii]
-        myd["FIBERMAP"]["MAG_{}".format(band.upper())] = get_lsst_mags(tmp_ws, tmp_fs, band)
+        myd["FIBERMAP"]["MAG_{}".format(band.upper())] = get_lsst_mags(
+            tmp_ws, tmp_fs, band
+        )
 
     # AR template: add noise from a randomly picked sky fiber
     myd["FIBERMAP"]["SKY_TARGETID"] = sky["TARGETID"][ii_sky]

--- a/py/desihiz/simcoadd_utils.py
+++ b/py/desihiz/simcoadd_utils.py
@@ -483,6 +483,8 @@ def get_lsst_mags(ws, fs, band, year=2023, np_round=2):
         log.error(msg)
         raise ValueError(msg)
 
+    mags = mags.round(np_round)
+
     return mags
 
 


### PR DESCRIPTION
This PR brings a small refinement on PR https://github.com/araichoor/desihiz/pull/23: it allows the user to either choose only grid values for the (z, mag), as was previously done, or draw random distributions inside the grid points.

This is controlled with these two arguments:
```
  --z_pick {grid,continuous}
                        pick z values on a grid, or in continuous values? (default=grid)
  --mag_pick {grid,continuous}
                        pick mag values on a grid, or in continuous values? (default=grid)
```

Note that a consequence here is that the number of generated spectra will change according to that choice:
- if `grid`: the code will work with"nedge" values;
- if `continuous`: the code will work with "nbin" (i.e. "nedge" - 1) values.

Also, the arguments of the `simcoadd_utils.get_lsst_mags()` and the `simcoadd_utils.get_sim()` functions are modified.