### PR TITLE
rescale_template2mag(): bugfix

### DIFF
--- a/py/desihiz/simcoadd_utils.py
+++ b/py/desihiz/simcoadd_utils.py
@@ -419,7 +419,7 @@ def rescale_template2mag(ws, fs, mag, mag_band, verbose=False):
     if (pad_ws.min() > filter_response.wavelength.min()) | (
         pad_ws.max() < filter_response.wavelength.max()
     ):
-        pad_ws, pad_fs = filter_response.pad_spectrum(pad_fs, pad_ws, method="zero")
+        pad_fs, pad_ws = filter_response.pad_spectrum(pad_fs, pad_ws, method="zero")
     # AR now scale
     orig_mag = filter_response.get_ab_magnitude(pad_fs * fluxunits, pad_ws)
     scalefac = 10 ** ((orig_mag - mag) / 2.5)


### PR DESCRIPTION
This PR fixes a small bug.

Hopefully, this part of the code is not used so far -- otherwise I suspect the code would have crashed with non-increasing "wavelengths".

If I m correct, the reason it didn t crash so far is:
- the `rrtemplate-lbg.fits` templates have `500 < rf_ws < 12000`; so at z=2 (resp. 5) this corresponds to `1500 < ws < 36000` (resp. `3000 < ws < 72000`)
- the speclite `lsst` filters cover `[3052, 10996]` (2016 version) or `[3199, 10990]` (2023 version).
so the template (obs.-frame) wavelength range covers the speclite `lsst` filter curves for `2 < z < 5`.