### PR TITLE
Tertiary37

### DIFF
--- a/py/desihiz/hizmerge_io.py
+++ b/py/desihiz/hizmerge_io.py
@@ -78,9 +78,7 @@ def get_img_dir(img):
         imgdir: folder path (str)
     """
     assert img in allowed_imgs
-    imgdir = os.path.join(
-        os.getenv("DESI_ROOT"), "users", "raichoor", "laelbg", img
-    )
+    imgdir = os.path.join(os.getenv("DESI_ROOT"), "users", "raichoor", "laelbg", img)
     return imgdir
 
 
@@ -430,7 +428,7 @@ def get_vi_fns(img):
         fns = [
             os.path.join(mydir, "FINAL_VI_ODIN_N501_20231012.fits"),
             os.path.join(mydir, "FINAL_VI_ODIN_N419_20231129.fits"),
-            os.path.join(mydir, "FINAL_VI_ODIN_N673_20240507.fits")
+            os.path.join(mydir, "FINAL_VI_ODIN_N673_20240507.fits"),
         ]
 
     if img == "suprime":
@@ -1446,7 +1444,9 @@ def get_phot_fns(img, case, band, photdir=None, v2=None):
             mydict["cosmos_yr2_{}".format(tmpband)] = [os.path.join(photdir, basefn)]
             # no I427 selection for tertiary37
             if tmpband != "I427":
-                mydict["cosmos_yr3_{}".format(tmpband)] = [os.path.join(photdir, basefn)]
+                mydict["cosmos_yr3_{}".format(tmpband)] = [
+                    os.path.join(photdir, basefn)
+                ]
 
     # clauds
     if img == "clauds":

--- a/py/desihiz/hizmerge_io.py
+++ b/py/desihiz/hizmerge_io.py
@@ -32,7 +32,7 @@ log = get_logger()
 allowed_imgs = ["odin", "suprime", "clauds"]
 allowed_img_cases = {
     "odin": ["cosmos_yr1", "xmmlss_yr2", "cosmos_yr2"],
-    "suprime": ["cosmos_yr2"],
+    "suprime": ["cosmos_yr2", "cosmos_yr3"],
     "clauds": ["cosmos_yr1", "xmmlss_yr2", "cosmos_yr2"],
 }
 allowed_cases = []
@@ -204,6 +204,10 @@ def get_specprod(case):
 
         specprod = "iron"
 
+    elif case == "cosmos_yr3":
+
+        specprod = "loa"
+
     else:
 
         specprod = "daily"
@@ -248,6 +252,10 @@ def get_specdir(img, case):
         if case == "cosmos_yr2":
 
             casedir = "tertiary26-thru20230416-v2"
+
+        if case == "cosmos_yr3":
+
+            casedir = "tertiary37-thru20240309-loa"
 
     if img == "clauds":
 
@@ -428,7 +436,11 @@ def get_vi_fns(img):
     if img == "suprime":
 
         mydir = os.path.join(get_img_dir("suprime"), "vi")
-        fns = [os.path.join(mydir, "FINAL_VI_Subaru_COSMOS_v20230803.fits.gz")]
+        fns = [
+            os.path.join(mydir, "FINAL_VI_Subaru_COSMOS_v20230803.fits.gz"),
+            os.path.join(mydir, "all_VI_Subaru_COSMOS_tertiary37.fits.gz"),
+            os.path.join(mydir, "all_VI_COSMOS_LBG_CLAUDS.fits.gz"),
+        ]
 
     if img == "clauds":
 
@@ -466,19 +478,26 @@ def read_vi_fn(fn):
     # - suprime: add dummy VI_SPECTYPE_FINAL
     # - rename columns
     if (basename in basenames["odin"]) | (basename in basenames["suprime"]):
-        key_olds = [
-            "VI_Z_FINAL",
-            "VI_QUALITY_FINAL",
-            "VI_SPECTYPE_FINAL",
-            "VI_COMMENTS_FINAL",
-        ]
-        key_news = ["VI_Z", "VI_QUALITY", "VI_SPECTYPE", "VI_COMMENTS"]
-        if basename in basenames["odin"]:
-            key_olds = ["VI_TARGETID"] + key_olds
-            key_news = ["TARGETID"] + key_news
-        if basename in basenames["suprime"]:
-            d["VI_SPECTYPE_FINAL"] = np.zeros(len(d), dtype="<U10")
-            log.info("{}\t: add dummy VI_SPECTYPE_FINAL".format(basename))
+        if basename in [
+            "all_VI_Subaru_COSMOS_tertiary37.fits.gz",
+            "all_VI_COSMOS_LBG_CLAUDS.fits.gz",
+        ]:
+            key_olds = ["VI_TARGETID", "VI_COMMENT"]
+            key_news = ["TARGETID", "VI_COMMENTS"]
+        else:
+            key_olds = [
+                "VI_Z_FINAL",
+                "VI_QUALITY_FINAL",
+                "VI_SPECTYPE_FINAL",
+                "VI_COMMENTS_FINAL",
+            ]
+            key_news = ["VI_Z", "VI_QUALITY", "VI_SPECTYPE", "VI_COMMENTS"]
+            if basename in basenames["odin"]:
+                key_olds = ["VI_TARGETID"] + key_olds
+                key_news = ["TARGETID"] + key_news
+            if basename in basenames["suprime"]:
+                d["VI_SPECTYPE_FINAL"] = np.zeros(len(d), dtype="<U10")
+                log.info("{}\t: add dummy VI_SPECTYPE_FINAL".format(basename))
         for key_old, key_new in zip(key_olds, key_news):
             d[key_old].name = key_new
             log.info("{}\t: rename {} to {}".format(basename, key_old, key_new))
@@ -632,7 +651,7 @@ def get_coaddfns(img, case):
 
     if img in ["odin", "suprime", "clauds"]:
 
-        if case == "cosmos_yr2":
+        if case in ["cosmos_yr2", "cosmos_yr3"]:
 
             coaddfns = sorted(glob(os.path.join(specdir, "coadd-27???.fits")))
 
@@ -730,11 +749,15 @@ def get_img_infos(img, case, stdsky):
 
         if img == "suprime":
 
-            from desihiz.hizmerge_suprime import get_suprime_cosmos_yr2_infos
+            from desihiz.hizmerge_suprime import (
+                get_suprime_cosmos_yr2_infos,
+                get_suprime_cosmos_yr3_infos,
+            )
 
             if case == "cosmos_yr2":
-
                 mydict = get_suprime_cosmos_yr2_infos()
+            if case == "cosmos_yr3":
+                mydict = get_suprime_cosmos_yr3_infos()
 
         if img == "clauds":
 
@@ -1418,10 +1441,12 @@ def get_phot_fns(img, case, band, photdir=None, v2=None):
         else:
 
             basefn = "Subaru_tractor_forced_all.fits.gz"
-        mydict = {
-            "cosmos_yr2_{}".format(band): [os.path.join(photdir, basefn)]
-            for band in get_img_bands("suprime")
-        }
+        mydict = {}
+        for tmpband in get_img_bands("suprime"):
+            mydict["cosmos_yr2_{}".format(tmpband)] = [os.path.join(photdir, basefn)]
+            # no I427 selection for tertiary37
+            if tmpband != "I427":
+                mydict["cosmos_yr3_{}".format(tmpband)] = [os.path.join(photdir, basefn)]
 
     # clauds
     if img == "clauds":
@@ -2034,6 +2059,8 @@ def get_spec_table(img, case, stack_s, mydict):
                 vi = read_vi_fn(fn)
 
                 # we beforehand removed possible duplicates in the vi catalog
+                # TODO
+                # well, actually maybe not true for suprime/cosmos_yr3...
                 for iiband in iibands:
 
                     iivi = np.where(vi["TARGETID"] == d["TARGETID"][iiband])[0]

--- a/py/desihiz/hizmerge_suprime.py
+++ b/py/desihiz/hizmerge_suprime.py
@@ -292,7 +292,11 @@ def get_suprime_cosmos_yr3_infos():
 
     # row-match
     rows = -99 + np.zeros(len(d), dtype=int)
-    for key in ["LBG_SUPRIME_NEW_ROW", "LBG_SUPRIME_2H_NEW_ROW", "LBG_SUPRIME_REOBS_ROW"]:
+    for key in [
+        "LBG_SUPRIME_NEW_ROW",
+        "LBG_SUPRIME_2H_NEW_ROW",
+        "LBG_SUPRIME_REOBS_ROW",
+    ]:
         sel = (d[key] != -99) & (rows == -99)
         sel2 = (d[key] != -99) & (rows != -99)
         assert np.all(d[key][sel2] == rows[sel2])
@@ -306,8 +310,8 @@ def get_suprime_cosmos_yr3_infos():
     sel = d["PRIORITY_INIT"] >= 7500
     assert np.all(t["RA"][sel] == d["RA"][sel])
     assert np.all(t["DEC"][sel] == d["DEC"][sel])
-    d_cs = SkyCoord(ra = d["RA"] * units.deg, dec = d["DEC"] * units.deg, frame="icrs")
-    t_cs = SkyCoord(ra = t["RA"] * units.deg, dec = t["DEC"] * units.deg, frame="icrs")
+    d_cs = SkyCoord(ra=d["RA"] * units.deg, dec=d["DEC"] * units.deg, frame="icrs")
+    t_cs = SkyCoord(ra=t["RA"] * units.deg, dec=t["DEC"] * units.deg, frame="icrs")
     sel = d["PRIORITY_INIT"] < 7500
     assert d_cs[sel].separation(t_cs[sel]).to(units.arcsec).value.max() < 1.0
 

--- a/py/desihiz/hizmerge_suprime.py
+++ b/py/desihiz/hizmerge_suprime.py
@@ -244,6 +244,163 @@ def get_suprime_cosmos_yr2_infos():
     return mydict
 
 
+def get_suprime_cosmos_yr3_infos():
+    """
+    Get the minimal photometric infos for SUPRIME cosmos_yr3 (tertiary37)
+
+    Args:
+        None
+
+
+    Returns:
+        mydict: dictionary with {keys: arrays},
+            with keys: TARGETID, TERTIARY_TARGET, PHOT_RA, PHOT_DEC, PHOT_SELECTION
+    """
+    fadir = os.path.join(
+        os.getenv("DESI_ROOT"), "survey", "fiberassign", "special", "tertiary", "0037"
+    )
+
+    bands = get_img_bands("suprime")
+
+    # first read the tertiary37 file
+    fn = os.path.join(fadir, "tertiary-targets-0037-assign.fits")
+    d = Table.read(fn)
+
+    # cut on suprime targets
+    sel = (d["LBG_SUPRIME_NEW"]) | (d["LBG_SUPRIME_2H_NEW"]) | (d["LBG_SUPRIME_REOBS"])
+    d = d[sel]
+
+    # initialize (with grabbing correct datamodel)
+    tmpdict = get_init_infos("suprime", [len(d), 0, 0, 0, 0])[bands[0]]
+
+    for key in ["PHOT_RA", "PHOT_DEC", "PHOT_SELECTION"]:
+
+        d[key] = tmpdict[key]
+
+    for band in bands:
+
+        d[band] = False
+
+    # to handle bytes / str differences downstream...
+    empty_suprime_selection = d["PHOT_SELECTION"][0]
+
+    log.info("# CHECKER BAND NTARG")
+
+    # Anand s targets file
+    fn = os.path.join(fadir, "inputcats", "cosmos_yr3-lbg-suprime.fits")
+    t = Table(fitsio.read(fn))
+
+    # row-match
+    rows = -99 + np.zeros(len(d), dtype=int)
+    for key in ["LBG_SUPRIME_NEW_ROW", "LBG_SUPRIME_2H_NEW_ROW", "LBG_SUPRIME_REOBS_ROW"]:
+        sel = (d[key] != -99) & (rows == -99)
+        sel2 = (d[key] != -99) & (rows != -99)
+        assert np.all(d[key][sel2] == rows[sel2])
+        rows[sel] = d[key][sel]
+    assert np.all(rows != -99)
+    t = t[rows]
+
+    # sanity check
+    # - PRIORITY_INIT = 8000,7500 -> targets from suprime, top-priority
+    # - lower PRIORITY_INIT -> targets can be from unions, 1-arsec-radius max
+    sel = d["PRIORITY_INIT"] >= 7500
+    assert np.all(t["RA"][sel] == d["RA"][sel])
+    assert np.all(t["DEC"][sel] == d["DEC"][sel])
+    d_cs = SkyCoord(ra = d["RA"] * units.deg, dec = d["DEC"] * units.deg, frame="icrs")
+    t_cs = SkyCoord(ra = t["RA"] * units.deg, dec = t["DEC"] * units.deg, frame="icrs")
+    sel = d["PRIORITY_INIT"] < 7500
+    assert d_cs[sel].separation(t_cs[sel]).to(units.arcsec).value.max() < 1.0
+
+    # get suprime_ra, suprime_dec
+    d["PHOT_RA"], d["PHOT_DEC"] = t["RA"], t["DEC"]
+
+    # get band + selection
+    for band in bands:
+
+        # no I427 selection for cosmos_yr3
+        if band == "I427":
+            continue
+
+        ii = np.where(t["SEL_{}".format(band)])[0]
+
+        if ii.size == 0:
+
+            continue
+
+        d[band][ii] = True
+        selname = "AR_{}".format(band)
+        for i in ii:
+
+            if d["PHOT_SELECTION"][i] == empty_suprime_selection:
+
+                d["PHOT_SELECTION"][i] = selname
+
+            else:
+
+                d["PHOT_SELECTION"][i] += "; {}".format(selname)
+
+        log.info("AR\t{}\t{}".format(band, ii.size))
+
+    # sanity check
+    ## all rows are filled
+    assert np.all(d["TERTIARY_TARGET"] != 0)
+    assert np.all(d["PHOT_RA"] != 0)
+    assert np.all(d["PHOT_DEC"] != 0)
+    assert np.all(d["PHOT_SELECTION"] != empty_suprime_selection)
+    ## - if TERTIARY_TARGET=LBG_SUPRIME_NEW,LBG_SUPRIME_2H_NEW:
+    ##       (ra, dec) should be exactly the same
+    ##   else:
+    ##       (ra, dec) are those from higher priority catalog
+    ##       and should be within 1 arcsec
+    sel = np.array(
+        [
+            _ == "LBG_SUPRIME_NEW" or _ == "LBG_SUPRIME_2H_NEW"
+            for _ in d["TERTIARY_TARGET"]
+        ]
+    )
+    fa_cs = SkyCoord(d["RA"] * units.degree, d["DEC"] * units.degree, frame="icrs")
+    suprime_cs = SkyCoord(
+        d["PHOT_RA"] * units.degree, d["PHOT_DEC"] * units.degree, frame="icrs"
+    )
+    seps = fa_cs.separation(suprime_cs).to("arcsec").value
+    assert np.all(seps[sel] == 0)
+    assert np.all(seps[~sel] < 1)
+
+    #
+    mydict = get_init_infos("suprime", [d[band].sum() for band in bands])
+
+    for band in bands:
+
+        # no I427 selection for cosmos_yr3
+        if band == "I427":
+            continue
+
+        sel = d[band]
+        mydict[band]["TARGETID"] = d["TARGETID"][sel]
+        mydict[band]["TERTIARY_TARGET"] = d["TERTIARY_TARGET"][sel]
+        mydict[band]["PHOT_RA"] = d["RA"][sel]
+        mydict[band]["PHOT_DEC"] = d["DEC"][sel]
+        mydict[band]["PHOT_SELECTION"] = d["PHOT_SELECTION"][sel].astype(
+            mydict[band]["PHOT_SELECTION"].dtype
+        )
+
+    ## check
+    for band in bands:
+
+        names, counts = np.unique(d["TERTIARY_TARGET"][d[band]], return_counts=True)
+        log.info(
+            "{} ({}):\t{}".format(
+                band,
+                d[band].sum(),
+                ", ".join(
+                    ["{}={}".format(name, count) for name, count in zip(names, counts)]
+                ),
+            )
+        )
+
+    return mydict
+
+
 # get photometry infos (targetid, brickname, objid)
 # this is for suprime targets only
 # sky/std will have dummy values
@@ -344,7 +501,7 @@ def get_suprime_phot_infos(case, d, photdir=None, v2=False):
             # - I527: 0/98
             # for those, we let the bricknames, objids, targfns empty
 
-            if not v2:
+            if (case == "cosmos_yr2") & (not v2):
 
                 sel_diff = d2d != 0
 
@@ -405,18 +562,36 @@ def get_suprime_phot_infos(case, d, photdir=None, v2=False):
             objids[iid] = t["OBJID"][iit]
             targfns[iid] = fn
 
-        # not_v2 : verify all objects are matched
-        # v2 : verify the expected non-matched
+        # cosmos_yr2:
+        # - not v2 : verify all objects are matched
+        # - v2 : verify the expected non-matched
+        # cosmos_yr3:
+        # - not v2: one no-matching for I527
+        # - v2: all objects are matched
+        n_nomatch = 0
+        if case == "cosmos_yr2":
 
-        if v2:
+            if v2:
 
-            n_nomatch = {
-                "I427": 6,
-                "I464": 27,
-                "I484": 9,
-                "I505": 18,
-                "I527": 0,
-            }[band]
+                n_nomatch = {
+                    "I427": 6,
+                    "I464": 27,
+                    "I484": 9,
+                    "I505": 18,
+                    "I527": 0,
+                }[band]
+
+        elif case == "cosmos_yr3":
+
+            if not v2:
+
+                n_nomatch = {
+                    "I427": 0,
+                    "I464": 0,
+                    "I484": 0,
+                    "I505": 0,
+                    "I527": 1,
+                }[band]
 
         else:
 


### PR DESCRIPTION
This PR adds the `tertiary37` data (`cosmos_yr3`) to the `desi-suprime` catalogs.

Few comments:
- I did not code up the propagation in `PHOT_SELECTION` if the `tertiary26` targets pass the `tertiary37` selection, and vice-versa; as that would had significant number of code lines, and ideally that should also be done for the clauds spectra, etc; so I leave that to be done independently;
- there are two new VI files (courtesy of Arjun!):
   - `all_VI_Subaru_COSMOS_tertiary37.fits.gz` (893 spectra): all observed `tertiary37` suprime spectra, except the `LBG_SUPRIME_REOBS` ones;
   - `all_VI_COSMOS_LBG_CLAUDS.fits.gz` (150 spectra): the already observed clauds-selected spectra which passed the suprime target selection tested in `tertiary37`, but where not put for re-observation, as they already have large efftime.
 
Note that `all_VI_COSMOS_LBG_CLAUDS.fits.gz` and `FINAL_VI_Subaru_COSMOS_v20230803.fits.gz` have 70 `TARGETID` in common.
That s my bad, as those are targets which both passing the clauds and suprime target selections in `tertiary26`; I forgot about those when generating the 150 `TARGETID` list.
For those 70 `TARGETID`, the code picks up the VI information from `all_VI_COSMOS_LBG_CLAUDS.fits.gz`, as it is the last listed file.