### PR TITLE
Tertiary37 clauds

### DIFF
--- a/py/desihiz/hizmerge_clauds.py
+++ b/py/desihiz/hizmerge_clauds.py
@@ -603,7 +603,7 @@ def get_clauds_phot_infos(case, d, photdir=None, v2=None):
                         "LBG_SUPRIME_2H_NEW",
                         "LBG_HSC_NEW",
                         "LBG_HSC_REOBS",
-                   ]
+                    ],
                 }
 
                 photnames = d["PHOT_SELECTION"][ii_band][iid][sel_diff].astype(str)

--- a/py/desihiz/hizmerge_clauds.py
+++ b/py/desihiz/hizmerge_clauds.py
@@ -391,6 +391,56 @@ def get_clauds_cosmos_yr2_infos():
     return mydict
 
 
+def get_clauds_cosmos_yr3_infos():
+    """
+    Get the minimal photometric infos for CLAUDS cosmos_yr3 (tertiary37)
+
+    Args:
+        None
+
+    Returns:
+        mydict: dictionary with {keys: arrays},
+            with keys: TARGETID, TERTIARY_TARGET, PHOT_RA, PHOT_DEC, PHOT_SELECTION
+
+    Notes:
+        The LBG_UNIONS_NEW,LBG_UNIONS_REOBS target selection is done on clauds photometry
+            degraded to the UNION depths; I do not have this photometry at hand.
+        We will propagate the CLAUDS photometry.
+        Same, I do not know which one is UGR or USGR, so I consider everything as UGR.
+        Also, the (RA, DEC) should be the exact same ones as in CLAUDS, except for the
+            targets coming from higher-priority selections (from suprime, hsc).
+    """
+    #
+    fadir = os.path.join(
+        os.getenv("DESI_ROOT"), "survey", "fiberassign", "special", "tertiary", "0037"
+    )
+
+    # first read the tertiary37 file
+    fn = os.path.join(fadir, "tertiary-targets-0037-assign.fits")
+    d = Table.read(fn)
+
+    # cut on lbg targets
+    sel = np.zeros(len(d), dtype=bool)
+    for name in ["LBG_UNIONS_NEW", "LBG_UNIONS_REOBS"]:
+        sel |= d[name]
+    d = d[sel]
+
+    d["PHOT_SELECTION"] = "COSMOS_YR3_UNIONS"
+
+    nrows = [len(d), 0, 0]
+    mydict = get_init_infos("clauds", nrows)
+
+    for band in ["UGR"]:
+
+        mydict[band]["TARGETID"] = d["TARGETID"]
+        mydict[band]["TERTIARY_TARGET"] = d["TERTIARY_TARGET"]
+        mydict[band]["PHOT_RA"] = d["RA"]
+        mydict[band]["PHOT_DEC"] = d["DEC"]
+        mydict[band]["PHOT_SELECTION"] = d["PHOT_SELECTION"]
+
+    return mydict
+
+
 # get photometry infos (clauds_id)
 # this is for clauds targets only
 # sky/std will have dummy values
@@ -548,11 +598,17 @@ def get_clauds_phot_infos(case, d, photdir=None, v2=None):
                         "LAE_SUB4OBS",
                         "LAE_ODI4OBS",
                     ],
+                    "COSMOS_YR3_UNIONS": [
+                        "LBG_SUPRIME_NEW",
+                        "LBG_SUPRIME_2H_NEW",
+                        "LBG_HSC_NEW",
+                        "LBG_HSC_REOBS",
+                   ]
                 }
 
                 photnames = d["PHOT_SELECTION"][ii_band][iid][sel_diff].astype(str)
                 ischecked = np.zeros(len(tertiary_targets), dtype=bool)
-                for photname in list(hip_targs.keys()):
+                for photname in hip_targs:
                     sel = np.array([photname in _ for _ in photnames])
                     log.info(
                         "{}\t{}\t{} in PHOT_SELECTION\thip_targs={}\tnp.unique(tertiary_targets)={}".format(

--- a/py/desihiz/hizmerge_io.py
+++ b/py/desihiz/hizmerge_io.py
@@ -33,7 +33,7 @@ allowed_imgs = ["odin", "suprime", "clauds"]
 allowed_img_cases = {
     "odin": ["cosmos_yr1", "xmmlss_yr2", "cosmos_yr2"],
     "suprime": ["cosmos_yr2", "cosmos_yr3"],
-    "clauds": ["cosmos_yr1", "xmmlss_yr2", "cosmos_yr2"],
+    "clauds": ["cosmos_yr1", "xmmlss_yr2", "cosmos_yr2", "cosmos_yr3"],
 }
 allowed_cases = []
 for img in allowed_img_cases:
@@ -264,6 +264,10 @@ def get_specdirs(img, case):
         if case == "cosmos_yr2":
 
             casedirs = ["tertiary26-thru20230416-loa"]
+
+        if case == "cosmos_yr3":
+
+            casedirs = ["tertiary37-thru20240309-loa"]
 
     specdirs = [
         os.path.join(spec_rootdir, specprod, "healpix", casedir) for casedir in casedirs
@@ -757,6 +761,7 @@ def get_img_infos(img, case, stdsky):
                 get_clauds_cosmos_yr1_infos,
                 get_clauds_xmmlss_yr2_infos,
                 get_clauds_cosmos_yr2_infos,
+                get_clauds_cosmos_yr3_infos,
             )
 
             if case == "cosmos_yr1":
@@ -765,6 +770,8 @@ def get_img_infos(img, case, stdsky):
                 mydict = get_clauds_xmmlss_yr2_infos()
             if case == "cosmos_yr2":
                 mydict = get_clauds_cosmos_yr2_infos()
+            if case == "cosmos_yr3":
+                mydict = get_clauds_cosmos_yr3_infos()
 
     bands = get_img_bands(img)
     for band in bands:
@@ -1454,6 +1461,7 @@ def get_phot_fns(img, case, band, photdir=None, v2=None):
             "xmmlss_yr2_USGR": [get_clauds_fn("xmmlss_yr2", v2=v2, uband="uS")],
             "cosmos_yr2_UGR": [get_clauds_fn("cosmos_yr2", v2=v2, uband="u")],
             "cosmos_yr2_USGR": [get_clauds_fn("cosmos_yr2", v2=v2, uband="uS")],
+            "cosmos_yr3_UGR": [get_clauds_fn("cosmos_yr3", v2=v2, uband="u")],
         }
 
     if "{}_{}".format(case, band) in mydict:


### PR DESCRIPTION
This PR adds the spectra from the `tertiary37` (`cosmos_yr3`) observations, selected as UNIONS-like targets, i.e. from CLAUDS photometry degraded to UNIONS depths.

Note that propagated photometry is the CLAUDS one.
Also, as I do not know which one is UGR or USGR, so I consider everything as UGR.